### PR TITLE
Throw new Error instead of string

### DIFF
--- a/lib/tech.js
+++ b/lib/tech.js
@@ -83,9 +83,8 @@ exports.Tech = INHERIT({
                     errorMessage += '\nError result in ' + errorFilename;
 
                     return this.write(out, res).then(function() {
-                        throw errorMessage;
+                        throw new Error(errorMessage);
                     });
-
                 }
             }
 


### PR DESCRIPTION
enb assumes "throw 'My Error'" as success result.