### PR TITLE
Fix unstable test results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4"

--- a/lib/tech.js
+++ b/lib/tech.js
@@ -61,8 +61,10 @@ exports.Tech = INHERIT({
                         out.end();
 
                         if (path != out.path) {
-                            // remove empty output file if input != ouput
-                            FS.unlinkSync(out.path);
+                            try {
+                                // remove empty output file if input != ouput
+                                FS.unlinkSync(out.path);
+                            } catch(e) {}
                         }
                     }
 

--- a/test/borschik-freeze.js
+++ b/test/borschik-freeze.js
@@ -9,7 +9,7 @@ describe('borschik freeze', function() {
 
     const testDir = PATH.resolve(__dirname, 'borschik-freeze');
     const freezeDir = PATH.resolve(testDir, '_');
-    const resFile = PATH.resolve(testDir, 'result.json');
+    const resFile = PATH.resolve(__dirname, '_borschik-freeze-result.json');
 
     afterEach(function(cb) {
         CP.exec('rm -rf ' + [freezeDir, resFile].join(' '), function() {
@@ -34,13 +34,12 @@ describe('borschik freeze', function() {
                         "borschik-freeze/a.css": "//yandex.st/prj/_LWJmVQ8Q4Kn5C4mK3iYXHyieR7g.css",
                         "borschik-freeze/js/1.js": "//yandex.st/prj/_s2waZ-cd23dy_WqyHXmzbhscY_k.js",
                         "borschik-freeze/js/subdir/2.js": "//yandex.st/prj/_MGOy381jDKO0QzbHxeo46xQNEtQ.js",
-                        "borschik-freeze/result.json": "borschik-freeze/result.json",
                         "borschik-freeze/test.png": "//yandex.st/prj/_wFPs-e1B3wMRud8TzGw7YHjS08I.png"
                     };
                     // console.log('ACTUAL');
                     // console.log(JSON.parse(json));
                     // console.log('EXPECTED');
-                    // console.log(res);    
+                    // console.log(res);
 
                     ASSERT.deepEqual(JSON.parse(json), res);
                     cb();


### PR DESCRIPTION
coa option with `.output()` creates output file with async.